### PR TITLE
fix: async deleteJWTcredential when changing password

### DIFF
--- a/apis/account.go
+++ b/apis/account.go
@@ -393,10 +393,13 @@ func ChangePassword(c *fiber.Ctx) error {
 	}
 
 	if !config.Config.Standalone {
-		err = kong.DeleteJwtCredential(user.ID)
-		if err != nil {
-			return err
-		}
+		userID := user.ID
+		go func() {
+			err = kong.DeleteJwtCredential(userID)
+			if err != nil {
+				log.Warn().Err(err).Int("user_id", userID).Msg("failed to delete jwt credential")
+			}
+		}()
 	}
 
 	accessToken, refreshToken, err := user.CreateJWTToken()


### PR DESCRIPTION
修改密码会调用DeleteJwtCredential函数
若用户很久没有登录，Kong里面没有他的JwtCredential，会导致DeleteJwtCredential报错

但这样同时忽略了ListJwtCredentials里面的其他错误，不知道是否有其他api可以验证kong中是否存在JwtCredentials